### PR TITLE
Hard-code base AUR git URI in aurpublish script

### DIFF
--- a/aurpublish.in
+++ b/aurpublish.in
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+REMOTE_URL='aur@aur.archlinux.org:'
+
 #### Declare common functions
 
 # usage and other awkward blocks of preformatted text
@@ -35,9 +37,8 @@ _EOF_
 ssh_config() {
 	cat <<- _EOF_
 		\`\`\`
-		Host aur aur.archlinux.org
+		Host aur.archlinux.org
 		    User aur
-		    Hostname aur.archlinux.org
 		    IdentityFile ~/.ssh/keys/aur
 		\`\`\`
 _EOF_
@@ -142,9 +143,9 @@ if (( PULL_SUBTREE )); then
     # test if prefix already exists
     if is_package_in_git ${package}; then
         git subtree split -P "${package}" --rejoin
-        git subtree pull -P "${package}" aur:${pkgbase}.git master -m "Merge subtree '${package}'"
+        git subtree pull -P "${package}" ${REMOTE_URL}/${pkgbase}.git master -m "Merge subtree '${package}'"
     else
-        git subtree add -P "${package}" aur:${package}.git master
+        git subtree add -P "${package}" ${REMOTE_URL}/${package}.git master
     fi
     exit 0
 fi
@@ -152,4 +153,4 @@ fi
 if (( SPEEDUP )); then
     git subtree split -P "${package}" --rejoin
 fi
-git subtree push -P "${package}" aur:${pkgbase}.git master
+git subtree push -P "${package}" ${REMOTE_URL}/${pkgbase}.git master

--- a/aurpublish.in
+++ b/aurpublish.in
@@ -147,6 +147,18 @@ fi
 if (( ! URL_SET )); then
     # use git configured remoteUrl, if set
     REMOTE_URL=$(git config --default "${REMOTE_URL}" --get aurpublish.remoteUrl | sed 's:/*$::')
+
+    # warn the user if they have a non-default ssh alias for 'aur'
+    auralias=$(ssh -G aur | awk '$1 == "hostname" { print $2 }')
+    if [[ ${auralias} != 'aur' && ${auralias} != 'aur.archlinux.org' ]]; then
+        echo "Warning: You have a non-default alias for 'aur' in your ssh configuration. (${auralias})"
+        echo "Previous versions of aurpublish used the 'aur' ssh hostname, but you should now use the --url option."
+        echo ""
+        echo "This operation will use the git server at: ${REMOTE_URL}"
+        echo ""
+        read -p "Do you wish to continue? [y/n] " userwarned
+        [[ ${userwarned} = [yY] ]] || exit 1
+    fi
 fi
 
 pkgbase="$(sed -rn 's/pkgbase = (.*)/\1/p' "${package}"/.SRCINFO 2>/dev/null)"

--- a/aurpublish.in
+++ b/aurpublish.in
@@ -22,6 +22,8 @@ usage() {
 		                      and a second copy of all commits in the subtree.
 		                      For more details, see the "--rejoin" option in git
 		                      subtree.
+		    -u, --url       Specify the URL of the server that should be used
+		                      for git operations.
 		    -h, --help      Show this usage message
 
 		COMMANDS
@@ -69,6 +71,11 @@ while [[ "${1}" != "" ]]; do
             ;;
         -s|--speedup)
             SPEEDUP=1
+            ;;
+        -u|--url)
+            REMOTE_URL=${2%/}
+            URL_SET=1
+            shift
             ;;
         log)
             LOG=1
@@ -135,6 +142,11 @@ if (( LOG )); then
     shift
     git log "${log_pre_opts[@]}" $(git subtree split -P "${package}") "$@"
     exit 0
+fi
+
+if (( ! URL_SET )); then
+    # use git configured remoteUrl, if set
+    REMOTE_URL=$(git config --default "${REMOTE_URL}" --get aurpublish.remoteUrl | sed 's:/*$::')
 fi
 
 pkgbase="$(sed -rn 's/pkgbase = (.*)/\1/p' "${package}"/.SRCINFO 2>/dev/null)"

--- a/doc/aurpublish.1.asciidoc
+++ b/doc/aurpublish.1.asciidoc
@@ -49,6 +49,9 @@ Options
         commits in the subtree. For more details, see the "--rejoin"
         option in linkman:git-subtree[1].
 
+*-u*, *--url* <URL>::
+        Specify the URL of the server that should be used for git operations.
+
 *-h*, *--help*::
         Prints a usage page.
 
@@ -62,6 +65,29 @@ Hooks
 *prepare-commit-msg*::
         Prefill the commit message with a list of added/updated/deleted
         packages + versions (if any).
+
+
+Specifying AUR server URL
+-------------------------
+You can use aurpublish to interact with a git server other than the default
+AUR git server at aur.archlinux.org. This may be useful if you are running
+your own AUR server.
+
+The upstream git server URL can be configured in two ways. You can set the
+URL with the -u/--url options when you run aurpublish. Or you can configure
+the server persistently in git by setting the aurpublish.remoteUrl option.
+
+Set the URL with --url::
+        aurpublish --url ssh://me@example.com mypackage
+
+Set the URL for the current git directory with git config::
+        git config aurpublish.remoteUrl ssh://me@example.com
+
+Set the URL globally with git config::
+        git config --global aurpublish.remoteUrl ssh://me@example.com
+
+For more details on git options see linkman:git-config[1].
+
 
 Examples
 --------
@@ -79,6 +105,9 @@ aurpublish ansible-core-git::
 
 aurpublish log::
         View the git log of a package subtree.
+
+aurpublish --url ssh://me@example.com ansible-core-git::
+        Push the subtree to a server at ssh://example.com.
 
 AUTHORS
 -------


### PR DESCRIPTION
This patch changes the AUR URI used in git commands from "aur:" to "ssh://aur@aur.archlinux.org". This change removes the requirement that the user have an alias for "aur:" in their ssh config in order for aurpublish to be able connect to the AUR git server.

**Testing:**
 * `make PREFIX=/usr` - make succeeds
 * `aurpublish [package]` - verified that pushing a new package works
 * `aurpublish -p [package]` - verified that pulling a new package works
 * `aurpublish -p [package]` - (repeat command) verified that pulling an existing package works

**Related issue:**
This pull request would resolve issue #18.

**Comments:**
 * Hard-coding the URI in the script feels like a good practice to follow, since it makes it explicit what host/protocol the script intends to connect to.
 * Removing the need for an alias makes this script compatible with the configuration recommended in the [AUR submission guidelines](https://wiki.archlinux.org/title/AUR_submission_guidelines#Authentication) topic in the Arch Wiki.
 * And I personally prefer not to use ssh aliases, because it feels like an indirection.