### PR TITLE
Add built versions of aurpublish files to git ignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,21 +1,3 @@
-# package src/pkg archives, downloaded sources
-*.tar*
-*.tgz
-*.zip
-
-# signed sources
-*.asc
-*.sig
-
-# log files from makepkg --log (or extra-x86_64-build)
-*.log
-
-# subfolders, e.g. source or built package trees, vcs
-*/**/
-
-# backup files
-*~
-*.bak
-
-# mkpkg status files, from soyuz.archlinux.org
-.mkpkg_check
+# built versions of aurpublish files
+/aurpublish
+/doc/aurpublish.1


### PR DESCRIPTION
These files were always showing up as untracked in `git status` while working on the aurpublish script. Since they are not meant to be committed, they should probably be included in the .gitignore list.